### PR TITLE
Reset counters and search offset to zero in prep for fresh results

### DIFF
--- a/addons/ambientcg/acg_ui.gd
+++ b/addons/ambientcg/acg_ui.gd
@@ -54,7 +54,13 @@ func delete_all_items():
 		active_download_panel = null
 
 func search_submitted(new_text: String) -> void:
+	## reset former counters for fresh search results
+	search_offset = 0
+	est_count = 0
+	cur_count = 0
+
 	request_for_key_words()
+
 func request_for_key_words(delete_before : bool = true):
 	get_node("%CenterContainer").hide()
 	load_progress.show()


### PR DESCRIPTION
Might resolve #7 

From what i could tell, the search seemed to be holding on to former values might have been mucking up fresh results from coming in, since the bug for me of failed searches was after subsequent searches in a row. But would go away if i clicked off that plugin scene and back to it.

So that suggested default values worked but repeat searches were failing, so maybe not a clean reset. So i set search_offest back to 0, that helped quite a bit but then had mixed search results after subsequent searches, (metal would stay even after searching for wood). But by reducing the est_ and cur _counts to zero it properly cleared former results, and brought in fresh results clean each time. So hopefully that solves it. 3 short lines to reset counters for each search.

I'm not intimate with the code base so feel free to reject this if I'm missing something key here.