### PR TITLE
Channelpack ORM files

### DIFF
--- a/addons/ambientcg/download_panel.gd
+++ b/addons/ambientcg/download_panel.gd
@@ -264,43 +264,6 @@ func extract(zip_file: String, file_name: String):
 	_on_cancel_pressed()
 	DirAccess.remove_absolute(zip_file)
 
-func configure_orm_import_settings(orm_path: String):
-	# Configure import settings for ORM texture
-	var import_path = orm_path + ".import"
-	
-	# Create proper import configuration for ORM texture
-	var config = ConfigFile.new()
-	config.set_value("remap", "importer", "texture")
-	config.set_value("remap", "type", "CompressedTexture2D")
-	
-	# Important: Disable sRGB for ORM textures since they contain data, not color
-	config.set_value("params", "compress/mode", 0)  # Lossless compression
-	config.set_value("params", "compress/high_quality", true)
-	config.set_value("params", "compress/lossy_quality", 0.7)
-	config.set_value("params", "compress/hdr_compression", 1)
-	config.set_value("params", "compress/normal_map", 0)
-	config.set_value("params", "compress/channel_pack", 0)
-	config.set_value("params", "mipmaps/generate", true)
-	config.set_value("params", "roughness/mode", 0)
-	config.set_value("params", "roughness/src_normal", "")
-	config.set_value("params", "process/fix_alpha_border", true)
-	config.set_value("params", "process/premult_alpha", false)
-	config.set_value("params", "process/normal_map_invert_y", false)
-	config.set_value("params", "process/hdr_as_srgb", false)
-	config.set_value("params", "process/hdr_clamp_exposure", false)
-	config.set_value("params", "process/size_limit", 0)
-	config.set_value("params", "detect_3d/compress_to", 0)  # Don't auto-detect as 3D
-	config.set_value("params", "svg/scale", 1.0)
-	
-	# Most importantly - disable sRGB conversion for data textures
-	config.set_value("params", "process/HDR_as_sRGB", false)
-	
-	var error = config.save(import_path)
-	if error != OK:
-		print("Failed to save import config for ORM texture: ", error)
-	else:
-		print("Configured import settings for ORM texture")
-
 func await_for_reimport():
 	var editor_fs: EditorFileSystem = EditorInterface.get_resource_filesystem()
 	while not is_equal_approx(1.0, editor_fs.get_scanning_progress()) and editor_fs.is_scanning():
@@ -406,9 +369,6 @@ func create_orm_texture(directory: String, file_name: String, valid_files: Array
 	
 	# Additional wait to ensure import is complete
 	await get_tree().create_timer(0.5).timeout
-	
-	# Try to configure the import settings for the ORM texture
-	#configure_orm_import_settings(orm_path)
 	
 	print("Created ORM texture: ", orm_path)
 	

--- a/addons/ambientcg/download_panel.tscn
+++ b/addons/ambientcg/download_panel.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=6 format=3 uid="uid://dfrcr8snmmxal"]
+[gd_scene load_steps=5 format=3 uid="uid://dfrcr8snmmxal"]
 
-[ext_resource type="Texture2D" uid="uid://be7bfntarygtk" path="res://icon.svg" id="1_k5w7h"]
 [ext_resource type="Script" uid="uid://dhs7ioi37elkg" path="res://addons/ambientcg/download_panel.gd" id="1_n6dyb"]
 [ext_resource type="Script" uid="uid://cn4gehailmkwg" path="res://addons/ambientcg/download_window.gd" id="1_yby7p"]
 [ext_resource type="Script" uid="uid://dc6nvcqhqblh4" path="res://addons/ambientcg/TmakerBG.gd" id="3_my73g"]
@@ -9,6 +8,7 @@
 bg_color = Color(0.509804, 0.435294, 1, 1)
 
 [node name="DownloadWindow" type="Window"]
+oversampling_override = 1.0
 title = "Test Window"
 initial_position = 4
 size = Vector2i(840, 420)
@@ -45,7 +45,6 @@ anchor_right = 0.271429
 anchor_bottom = 0.490476
 grow_horizontal = 2
 grow_vertical = 2
-texture = ExtResource("1_k5w7h")
 expand_mode = 1
 stretch_mode = 5
 metadata/_edit_use_anchors_ = true
@@ -139,19 +138,27 @@ text = "Triplanar UV"
 alignment = 1
 metadata/_edit_use_anchors_ = true
 
+[node name="ORMCheck" type="CheckBox" parent="DownloadWidget/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+button_pressed = true
+text = "Create ORM"
+alignment = 1
+metadata/_edit_use_anchors_ = true
+
 [node name="DownloadVisualizer" type="ColorRect" parent="DownloadWidget"]
 unique_name_in_owner = true
 visible = false
 self_modulate = Color(1, 1, 1, 0.588235)
 layout_mode = 1
-anchors_preset = 15
+anchors_preset = -1
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_right = -0.000366211
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-color = Color(0.188235, 0.188235, 0.188235, 1.5)
+color = Color(0.315, 0.35999998, 0.435, 1.5)
 script = ExtResource("3_my73g")
 multiplier = 1.5
 metadata/_custom_type_script = "uid://dc6nvcqhqblh4"


### PR DESCRIPTION
This one is worth testing a bit but i hope i got it all working smooth at this point. It should work for any scale of image downloaded, and the new checkbox gives you legacy separate files or channel packed ones.

Basically the new functions will checks for Roughness, Metallic, and AO textures, and builds a channel packed ORM file for them instead of keeping them all as separates. I imagine you already know but for folks looking to save space, and time, and VRAM in their game, channel packing like this is handy. Reducing a material from needing 7 texture files, down to 4 for reduces file load times, and how much has to be stored in RAM while the game is running.

I did notice some oddness if there isn't a materail folder yet, that Godot wouldn't always update the file explorer to show a materials folder now exists until i reloaded the project. I honestly don't know if that's a new behavior from my code, or something that has been happening for a while and I never noticed.